### PR TITLE
fix year and timezone of alert api doc

### DIFF
--- a/doc/api.apib
+++ b/doc/api.apib
@@ -1,6 +1,6 @@
 FORMAT: 1A
 
-# IOTインターン2021
+# IOTインターン
 
 ## アラート送信 [POST /api/v1/alert]
 

--- a/doc/api.apib
+++ b/doc/api.apib
@@ -1,6 +1,6 @@
 FORMAT: 1A
 
-# IOTインターン2020
+# IOTインターン2021
 
 ## アラート送信 [POST /api/v1/alert]
 
@@ -15,7 +15,7 @@ FORMAT: 1A
 
 + Response 200 (application/json)
     + Attributes
-      + `sent_at`: `2020-01-01T13:00:00Z` (string, required) - Linkitへの送信完了日時 (iso8601形式)
+      + `sent_at`: `2020-01-01T13:00:00Z` (string, required) - Linkitへの送信完了日時 (iso8601形式, UTC)
 
 + Response 400 (application/json)
     + RequestBodyが不正な場合に発生する


### PR DESCRIPTION
### 修正内容

- API仕様書の解答例のタイトルの年が「2020」になっている。
  - https://docs.google.com/spreadsheets/d/1yuT1Ich5j51C0doGiNwaHItZu80_raVrCXHkDAFEvnM/edit#gid=610772270&range=E26

- 仕様書を見ても timezone がわかりにくい
  - https://docs.google.com/spreadsheets/d/1yuT1Ich5j51C0doGiNwaHItZu80_raVrCXHkDAFEvnM/edit#gid=610772270&range=B39 