### PR TITLE
Script for downloading work of participants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ erl_crash.dump
 gear_config.json
 /doc/linkit_api.apib
 .DS_Store
+/tmp-downloaded

--- a/doc/for_organizer/operation/download_work_of_participants.md
+++ b/doc/for_organizer/operation/download_work_of_participants.md
@@ -1,0 +1,19 @@
+# 受講者の成果物をダウンロード
+
+EC2インスタンス上の`/home/intern-user/IoTIntern`をローカルにダウンロードする。
+
+## 前提
+
+- ダウンロード対象のEC2インスタンスには、tagとして`Name:iot-intern`が設定されているものとする
+- 全てのインスタンスで`intern-user`用のSSH鍵が共通であるとする
+
+## 手順
+
+[ダウンロードスクリプト](../../../script/aws/download_work_of_participants.sh)を実行する。
+
+```sh
+script/aws/download_work_of_participants.sh <path_to_ssh_key_for_intern-user>
+```
+
+ローカルにダウンロードされたディレクトリのパスは`IoTIntern/tmp-downloaded/<現在時刻>/iot-intern-<数字>`。
+`iot-intern-<数字>`の部分は[このスクリプト](../../../script/aws/list_public_ip_addresses.sh)で出力されるものと一致する。

--- a/doc/for_organizer/readme.md
+++ b/doc/for_organizer/readme.md
@@ -46,4 +46,5 @@
     - このレポジトリのmasterブランチを更新したとき
     - [Elixir講座のレポジトリのmasterブランチ](https://github.com/Fumipo-Theta/elixir-training)が更新された時
 - 必要な数のEC2インスタンスを起動 [(手順)](./operation/launch_instances_for_intern.md)
+- 受講者の成果物をローカルにダウンロード [(手順)](./operation/download_work_of_participants.md)
 - EC2インスタンスを終了 [(手順)](./operation/terminate_instances_for_intern.md)

--- a/script/aws/download_work_of_participants.sh
+++ b/script/aws/download_work_of_participants.sh
@@ -17,7 +17,7 @@ if [ $# -lt 1 ]; then
 fi
 
 REMOTE_TARGET_DIR="/home/${USER_NAME}/IoTIntern"
-now=$(gdate +%Y%m%d%H%M%S)
+now=$(date +%Y%m%d%H%M%S)
 LOCAL_DOWNLOAD_DIR="./tmp-downloaded/${now}"
 mkdir -p "${LOCAL_DOWNLOAD_DIR}"
 script_dir=$(dirname "$0")

--- a/script/aws/download_work_of_participants.sh
+++ b/script/aws/download_work_of_participants.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+USER_NAME="intern-user"
+
+usage(){
+  cat<<EOF
+Usage:
+  $(basename "$0") <path to ssh key for ${USER_NAME}>
+EOF
+}
+
+user_key_path="$1"
+
+if [ $# -lt 1 ]; then
+  usage
+  exit
+fi
+
+REMOTE_TARGET_DIR="/home/${USER_NAME}/IoTIntern"
+now=$(gdate +%Y%m%d%H%M%S)
+LOCAL_DOWNLOAD_DIR="./tmp-downloaded/${now}"
+mkdir -p "${LOCAL_DOWNLOAD_DIR}"
+script_dir=$(dirname "$0")
+
+for host_and_public_ip_pairs in $("${script_dir}/list_public_ip_addresses.sh"); do
+  hostname=$(echo "${host_and_public_ip_pairs}" | cut -d ',' -f1)
+  ip=$(echo "${host_and_public_ip_pairs}" | cut -d ',' -f2)
+  echo "Start downlading from ${hostname}..."
+
+  ssh -i "${user_key_path}" -o StrictHostKeyChecking=no "${USER_NAME}@${ip}" <<"EOC"
+rm -rf ${REMOTE_TARGET_DIR}/_build
+rm -rf ${REMOTE_TARGET_DIR}/deps
+EOC
+
+  scp -i "${user_key_path}" -o StrictHostKeyChecking=no -r "${USER_NAME}@${ip}:${REMOTE_TARGET_DIR}" "${LOCAL_DOWNLOAD_DIR}/${hostname}"
+  echo "Done."
+done

--- a/script/aws/download_work_of_participants.sh
+++ b/script/aws/download_work_of_participants.sh
@@ -27,7 +27,9 @@ for host_and_public_ip_pairs in $("${script_dir}/list_public_ip_addresses.sh"); 
   ip=$(echo "${host_and_public_ip_pairs}" | cut -d ',' -f2)
   echo "Start downlading from ${hostname}..."
 
-  ssh -i "${user_key_path}" -o StrictHostKeyChecking=no "${USER_NAME}@${ip}" <<"EOC"
+  # REMOTE_TARGET_DIR should be expanded before transferred to remote
+  # shellcheck disable=SC2087
+  ssh -i "${user_key_path}" -o StrictHostKeyChecking=no "${USER_NAME}@${ip}" <<EOC
 rm -rf ${REMOTE_TARGET_DIR}/_build
 rm -rf ${REMOTE_TARGET_DIR}/deps
 EOC

--- a/script/aws/list_public_ip_addresses.sh
+++ b/script/aws/list_public_ip_addresses.sh
@@ -11,9 +11,8 @@ list_public_ip_addresses(){
     | jq -r '.[].PublicIpAddress')
 
   index=0
-  echo "host, public_ip_address"
   for ip_address in ${ip_addresses}; do
-    echo "iot-intern-${index}, ${ip_address}"
+    echo "iot-intern-${index},${ip_address}"
     index=$((index + 1))
   done
 }


### PR DESCRIPTION
(レビュー優先度は低くしていただいて大丈夫です)

インターン終了後、参加者の成果物ダウンロードに使用したスクリプトです。
コードの確認に使うことを意図しています(障害発生の調査は意図していません)。

ダウンロード前に、リモートの`_build`と`deps`ディレクトリを削除するようにしています。
- 受講者が編集することはないため
- ダウンロード時間が長くなるため