### PR TITLE
[234235] Improve gear development environment

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,5 @@
 {
   "recommendations": [
-    "develiteio.api-blueprint-viewer",
-    "mjmcloug.vscode-elixir",
-    "mhutchie.git-graph",
-    "jebbs.plantuml",
     "ms-vscode-remote.remote-ssh"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,5 @@
     "-Xmx2g",
     "-DPLANTUML_LIMIT_SIZE=16384"
   ],
-  "plantuml.server": "https://www.plantuml.com/plantuml",
-  "elixirLS.dialyzerEnabled": false
+  "plantuml.server": "https://www.plantuml.com/plantuml"
 }

--- a/doc/for_participants/setup_local_tools.md
+++ b/doc/for_participants/setup_local_tools.md
@@ -19,6 +19,13 @@
 
 - [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh): (必須) ローカルのVSCodeからリモートマシン上のファイルを編集するために必要
 
+## Google Chrome
+
+- [ここ](https://www.google.com/intl/ja_jp/chrome/)からダウンロードしてインストール
+  - Gearにアクセスするためのwebブラウザとして推奨する
+- 他のブラウザではlocalhostにsub-domainを指定したとき名前解決されず、gearにアクセスできない場合がある(少なくともSafariが該当)
+  - そのようなブラウザで名前解決されるようにするには`/etc/hosts`に`127.0.0.1 iot-intern.localhost`を追記することが必要だが、誤操作によるリスクがあるため推奨しない
+
 ## Linkit
 
 Linkitには[アプリ版](https://support.jin-soku.biz/support/solutions/articles/48001140891-linkit%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E6%96%B9%E6%B3%95%EF%BC%88%E3%82%A2%E3%83%97%E3%83%AA%E7%89%88%EF%BC%89)(Android・iOS)と[ブラウザ版](https://support.jin-soku.biz/support/solutions/articles/48001140888-linkit%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E6%96%B9%E6%B3%95)があり、少なくともいずれかを使用できればOK。

--- a/doc/for_participants/setup_on_remote_machine.md
+++ b/doc/for_participants/setup_on_remote_machine.md
@@ -14,9 +14,10 @@ IoTInternでの開発を行う際に以下の拡張機能を利用する。
 - [Plant UML](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml): シーケンス図のレンダリングが可能
 - [API Blueprint Viewer](https://marketplace.visualstudio.com/items?itemName=develiteio.api-blueprint-viewer): OpenAPI形式の仕様書をレンダリング可能
 - [Git Graph](https://marketplace.visualstudio.com/items?itemName=mhutchie.git-graph): Gitのコミットグラフを可視化できる
-- [ElixirLS](https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls): syntax highlightingや入力補完、定義の参照や定義箇所への移動ができるようになる
-    - IoTInternで利用する際、最新のものではなくバージョン0.5.0を利用する必要がある
-    - これはIoTInternが依存するAntikytheraでErlangバージョン20系を使用していることによる
+- [vscode-elixir](https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir): syntax highlightingや入力補完ができるようになる
+    - [Elixir-LS](https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls)のほうが定義の参照や定義箇所への移動ができるなど高機能だが、下記の問題により無視できない不便さが生じたため使用していない
+        - IoTInternで利用する際、最新のものではなくバージョン0.5.0を利用しなければ拡張機能がクラッシュする(AntikytheraがErlangバージョン20系を要求することによる)
+        - IoTIntern gearコンパイル時にhexパッケージのコンパイルが失敗する場合がある(バックグラウンドでElixir-LSによるgearコンパイルが進行している時に処理がバッティングすることによる)
 
 ### インストール
 

--- a/script/util/bootstrap_amazonlinux2.sh
+++ b/script/util/bootstrap_amazonlinux2.sh
@@ -141,7 +141,6 @@ EOF
   # Compaile gear in advance
   #
 
-  # when do mix test, successful tests should be indicated
   su intern-user -c "cd /home/intern-user/${gear_dir_name} && mix deps.get && mix deps.get && MIX_ENV=dev mix compile && MIX_ENV=test mix compile"
   echo "[Done] compiled the gear"
 

--- a/script/util/bootstrap_amazonlinux2.sh
+++ b/script/util/bootstrap_amazonlinux2.sh
@@ -4,7 +4,8 @@ set -euo pipefail -o posix
 #
 # Edit this section before launching an EC2 instance for making AMI
 #
-iot_intern_repo_url="https://github.com/access-company/IoTIntern.git"
+gear_dir_name=IoTIntern
+iot_intern_repo_url="https://github.com/access-company/${gear_dir_name}.git"
 erlang_version="20.3.8.25"
 elixir_version="1.9.4"
 nodejs_version="10.23.0"
@@ -46,7 +47,6 @@ EOF
   #
   # Add linux users
   #
-  gear_dir_name="$(basename "${iot_intern_repo_url}" .git)"
 
   add_linux_user() {
     name="$1"

--- a/script/util/bootstrap_amazonlinux2.sh
+++ b/script/util/bootstrap_amazonlinux2.sh
@@ -145,65 +145,43 @@ EOF
   echo "[Done] compiled the gear"
 
   #
-  # Install jupyter notebook for elixir hands-on
+  # Prepare environment for elixir-training by using docker
+  # to avoid affecting the compilation environment of the iot-intern gear
   #
 
-  # Install jupyter
-  su intern-user -c "python3 -m pip install --upgrade pip"
-  su intern-user -c "python3 -m pip install jupyter"
-  echo "[Done] Installed jupyter"
+  # Install docker and docker-compose
+  sudo yum install -y docker
+  sudo systemctl start docker
+  sudo systemctl enable docker
+  sudo usermod -a -G docker intern-admin
+  curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+  echo "[Done] installed docker and docker-compose"
 
-  #
-  # Install IElixir (https://github.com/pprzetacznik/IElixir)
-  #
+  content=$(cat << "EOF"
+[Unit]
+Description=Elixir training
+Requires=docker.service
 
-  # sqlite3.h is required in IElixir
-  yum install -y sqlite-devel
+[Service]
+Environment=COMPOSE_FILE=/home/intern-user/IoTIntern/doc/elixir-training/docker/docker-compose.yml
 
-  # sodium
-  # https://download.libsodium.org/libsodium/releases/
-  cd /opt
-  curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz | tar -xz
-  cd libsodium-1.0.18
-  ./configure && make && make install
-  # zmq
-  cd /opt
-  wget https://github.com/zeromq/libzmq/releases/download/v4.2.0/zeromq-4.2.0.tar.gz
-  tar xfz zeromq-4.2.0.tar.gz && rm zeromq-4.2.0.tar.gz
-  cd zeromq-4.2.0
-  ./configure && make && make install
+ExecStartPre=-/usr/local/bin/docker-compose -f ${COMPOSE_FILE} down --volumes
+ExecStart=/usr/local/bin/docker-compose -f ${COMPOSE_FILE} up
+ExecStop=/usr/local/bin/docker-compose -f ${COMPOSE_FILE} down --volumes
 
-  cd /home/intern-user
-  su intern-user -c "git clone https://github.com/pprzetacznik/IElixir.git"
-  cd IElixir
-  su intern-user -c "git checkout 4785f3f3b9cf9d09399038cf6c4af438559d951a" # the last version compatible to elixir < 1.10
-  su intern-user -c "mix deps.get"
-  su intern-user -c "MIX_ENV=prod mix compile"
-  su - intern-user -c "cd /home/intern-user/IElixir && ./install_script.sh"
-  echo "[Done] Installed IElixir kernel"
+Restart=always
+Type=simple
 
-  # Configure the jupyter server
-  su - intern-user -c "jupyter notebook --generate-config"
-
-  content=$(cat << EOF
-conf = get_config()
-
-conf.NotebookApp.ip = '0.0.0.0'
-conf.NotebookApp.notebook_dir = '/home/intern-user/${gear_dir_name}/doc/elixir-training/notebooks'
-conf.NotebookApp.token = u''
-conf.NotebookApp.open_browser = False
-conf.NotebookApp.port = 8888
+[Install]
+WantedBy=multi-user.target
 EOF
   )
-  echo "${content}" > /home/intern-user/.jupyter/jupyter_notebook_config.py
 
-  # Configure the jupyter server to start automatically
-  #
-  # Use rc.local instead of systemd
-  #  because we couldn't find the way to make tools installed by asdf work
-  echo 'nohup su - intern-user -c "jupyter notebook" > /tmp/jupyter-notebook.log &' >> /etc/rc.local
-  chmod 755 /etc/rc.d/rc.local
-  echo "[Done] Configured jupyter server"
+  echo "${content}" > /etc/systemd/system/docker-compose-elixir-training.service
+  sudo systemctl start docker-compose-elixir-training
+  sudo systemctl enable docker-compose-elixir-training
+  echo "[Done] registerd docker-compose-elixir-training service"
 
   echo 'Finished all steps!'
 ) &> "$log"

--- a/script/util/install_vscode_extensions.sh
+++ b/script/util/install_vscode_extensions.sh
@@ -25,6 +25,5 @@ install_extension develiteio api-blueprint-viewer 0.9.4
 # https://marketplace.visualstudio.com/items?itemName=mhutchie.git-graph
 install_extension mhutchie git-graph 1.30.0
 
-# https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls
-# If version of the Erlang required by antikythera <= 20, version of the elixir-ls should be <= 0.5.0
-install_extension JakeBecker elixir-ls 0.5.0
+# https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir
+install_extension mjmcloug vscode-elixir 1.1.0


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/234235

- Web ブラウザとして Google  Chrome の使用を推奨
- VSCode 拡張機能: Elixir-LS をやめて vscode-elixir をインストールするようスクリプトを変更
- Jupyter notebook を docker container 内で稼働させるように変更
  - `docker-compose` コマンドによるコンテナ起動スクリプトをサービスとして登録するようにしました
  -  `/home/intern-user/IoTIntern/doc/elixir-training/docker/docker-compose.yml` に基づきコンテナを起動します
  - ※ Dockerfile、docker-compose.yml, notebook の実体は https://github.com/access-company/IoTIntern/pull/15 で取り込み予定です 

修正後のコードで AMI 作成・インスタンス立ち上げ・本番当日の流れに沿って作業 を行い、問題がないことを確認済みです。