### PR TITLE
[235517] Increase vCPUs of EC2 instance

### DIFF
--- a/script/aws/launch_instances.sh
+++ b/script/aws/launch_instances.sh
@@ -32,7 +32,7 @@ run_instances(){
     --profile iot_intern \
     --image-id "${image_id}" \
     --count "${instance_count}" \
-    --instance-type 't2.micro' \
+    --instance-type 't3.micro' \
     --security-group-ids "${security_group_id}" \
     --tag-specifications "ResourceType='instance',Tags=[{Key='Name',Value='iot-intern'}]"
 }


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/235517#note-4

docker で Jupyter notebook を使うようになった結果、hex パッケージコンパイル時の平均 CPU 使用率が100%に張り付き、
EC2 インスタンスが20分ほどハングアップすることがわかりました。

単純に CPU のリソース不足によるものと思われるので、料金がほぼ同じで vCPU が2倍 (1=>2) になる t3.micro を使うことにしました。