### PR TITLE
[249215] Update aws ec2 setup scripts

### DIFF
--- a/doc/for_organizer/operation/create_ami.md
+++ b/doc/for_organizer/operation/create_ami.md
@@ -29,6 +29,9 @@
   - Linkitの仕様書は本来内部向けのドキュメントであり、publicであるこのレポジトリに含めるべきではないため手動で設置する
   - パスは`/home/intern-user/IoTIntern/doc/linkit_api.apib`とする
   - 拡張子は`.apib`とすること(VSCodeのAPI Blueprint Viewer拡張機能でプレビューするために必要)
+- Visual Studio Code サーバーと拡張機能のインストール
+  - Visual Studio Code サーバーは、Remote - SSH による初回接続時に自動で EC2 へインストールされる
+  - Remote - SSH で EC2 に接続し、[スクリプト](../../../script/util/install_vscode_extensions.sh)で拡張機能をインストールする
 
 ### AMIの登録
 

--- a/script/aws/launch_makeami_instance.sh
+++ b/script/aws/launch_makeami_instance.sh
@@ -42,7 +42,7 @@ gen_block_device_mappings() {
         "DeviceName": "/dev/xvda",
         "Ebs": {
           "DeleteOnTermination": true,
-          "VolumeSize": 8,
+          "VolumeSize": 16,
           "VolumeType": "gp3"
         }
       }

--- a/script/util/bootstrap_amazonlinux2.sh
+++ b/script/util/bootstrap_amazonlinux2.sh
@@ -139,7 +139,7 @@ EOF
   echo "[Done] installed nodejs ${nodejs_version}"
 
   #
-  # Compaile gear in advance
+  # Compile gear in advance
   #
 
   su intern-user -c "cd /home/intern-user/${gear_dir_name} && mix deps.get && mix deps.get && MIX_ENV=dev mix compile && MIX_ENV=test mix compile"

--- a/script/util/install_vscode_extensions.sh
+++ b/script/util/install_vscode_extensions.sh
@@ -27,3 +27,6 @@ install_extension mhutchie git-graph 1.30.0
 
 # https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir
 install_extension mjmcloug vscode-elixir 1.1.0
+
+# https://marketplace.visualstudio.com/items?itemName=ms-vsliveshare.vsliveshare
+install_extension ms-vsliveshare vsliveshare 1.0.5669


### PR DESCRIPTION
https://gate.tok.access-company.com/redmine/issues/249215

変更点

- inkit api 仕様書の ec2 への配置済み
- disk space を 16GBに拡張
- ec2 への vscode extension は install 済み
- vscode live share の install と動作確認済み
