### PR TITLE
Fix filter of describe-images command

### DIFF
--- a/script/aws/launch_makeami_instance.sh
+++ b/script/aws/launch_makeami_instance.sh
@@ -23,7 +23,10 @@ find_image_id() {
   aws ec2 describe-images \
     --profile iot_intern \
     --owner amazon \
-    --filters "Name=name,Values=amzn2-ami-hvm-2.0.????????-x86_64-gp2" "Name=state,Values=available" \
+    --filters "Name=architecture,Values=x86_64" \
+      "Name=virtualization-type,Values=hvm" \
+      "Name=name,Values=amzn2-ami-kernel-*" \
+      "Name=state,Values=available" \
     --query Images \
   | jq -r "sort_by(.CreationDate)[-1].ImageId"
 }


### PR DESCRIPTION
amazon linux の image の名称に変更があったようで、ami setup script が error で失敗するようになっていたため、修正しました。

error 内容は下記。

```shell
$ ./script/aws/launch_makeami_instance.sh script/util/bootstrap_amazonlinux2.sh
+ run_instance
++ find_image_id
++ aws ec2 describe-images --profile iot_intern --owner amazon --filters 'Name=name,Values=amzn2-ami-hvm-2.0.????????-x86_64-gp2' Name=state,Values=available --query Images
++ jq -r 'sort_by(.CreationDate)[-1].ImageId'
+ image_id=null
++ find_subnet_id
++ aws ec2 describe-subnets --profile iot_intern --query 'Subnets[0].SubnetId' --output text
+ subnet_id=subnet-6cc01124
++ gen_block_device_mappings
++ echo '
    [
      {
        "DeviceName": "/dev/xvda",
        "Ebs": {
          "DeleteOnTermination": true,
          "VolumeSize": 16,
          "VolumeType": "gp3"
        }
      }
    ]
  '
++ jq --compact-output --monochrome-output .
+ block_device_mappings='[{"DeviceName":"/dev/xvda","Ebs":{"DeleteOnTermination":true,"VolumeSize":16,"VolumeType":"gp3"}}]'
++ date +%Y%m%d
+ instance_name=iot-intern-makeami-20220902
++ find_security_group_id
++ aws ec2 describe-security-groups --profile iot_intern --group-names iot-intern --query 'SecurityGroups[].GroupId' --output text
+ security_group_id=sg-0b984607c37982832
+ aws ec2 run-instances --profile iot_intern --image-id null --instance-type t3.micro --subnet-id subnet-6cc01124 --user-data file:///Users/hiroshi.nishigami/projects/intern/IoTIntern/script/util/bootstrap_amazonlinux2.sh --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"DeleteOnTermination":true,"VolumeSize":16,"VolumeType":"gp3"}}]' --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=iot-intern-makeami-20220902}]' --security-group-ids sg-0b984607c37982832

An error occurred (InvalidAMIID.Malformed) when calling the RunInstances operation: Invalid id: "null" (expecting "ami-...")
```

参考

- https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html
- https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/usingsharedamis-finding.html