### PR TITLE
Change response from 403 to 404

### DIFF
--- a/doc/elixir-training-with-livebook/notebooks/5 Control syntax.livemd
+++ b/doc/elixir-training-with-livebook/notebooks/5 Control syntax.livemd
@@ -43,7 +43,7 @@ case構文を使って、HTTPレスポンスを表すmapのパターンに応じ
 
 * `status`が200のとき、`:ok`と`body`の組のtupleを作る
 * `status`が400のとき、`:error`と`:bad_resuest`の組のtupleを作る
-* `status`が403のとき、`:error`と`:not_found`の組のtupleを作る
+* `status`が404のとき、`:error`と`:not_found`の組のtupleを作る
 * `status`が500のとき、`:error`と`:internal_error`の組のtupleを作る
 
 <!-- livebook:{"continue_on_error":true} -->

--- a/doc/elixir-training-with-livebook/notebooks/answers.livemd
+++ b/doc/elixir-training-with-livebook/notebooks/answers.livemd
@@ -197,7 +197,7 @@ result =
   case response do
     %{status: 200, body: body} -> {:ok, body}
     %{status: 400} -> {:error, :bad_request}
-    %{status: 403} -> {:error, :not_found}
+    %{status: 404} -> {:error, :not_found}
     %{status: 500} -> {:error, :internal_error}
   end
 

--- a/doc/elixir-training/notebooks/5 Control syntax.ipynb
+++ b/doc/elixir-training/notebooks/5 Control syntax.ipynb
@@ -71,7 +71,7 @@
     "case構文を使って、HTTPレスポンスを表すmapのパターンに応じて処理を以下のように分けてみよう。\n",
     "- `status`が200のとき、`:ok`と`body`の組のtupleを作る\n",
     "- `status`が400のとき、`:error`と`:bad_resuest`の組のtupleを作る\n",
-    "- `status`が403のとき、`:error`と`:not_found`の組のtupleを作る\n",
+    "- `status`が404のとき、`:error`と`:not_found`の組のtupleを作る\n",
     "- `status`が500のとき、`:error`と`:internal_error`の組のtupleを作る"
    ]
   },

--- a/doc/elixir-training/notebooks/answers.ipynb
+++ b/doc/elixir-training/notebooks/answers.ipynb
@@ -350,7 +350,7 @@
     "result = case response do\n",
     " %{status: 200, body: body} -> {:ok,    body}\n",
     " %{status: 400}             -> {:error, :bad_request}\n",
-    " %{status: 403}             -> {:error, :not_found}\n",
+    " %{status: 404}             -> {:error, :not_found}\n",
     " %{status: 500}             -> {:error, :internal_error}\n",
     "end\n",
     "\n",

--- a/lib/linkit.ex
+++ b/lib/linkit.ex
@@ -32,7 +32,7 @@
 #     # 仕様に沿った関数の戻り値を返せるように実装してください
 #     case Httpc.post(endpoint_url, {:json, req_body}, header) do
 #       {:ok, %{status: 201, body: res_body}} -> {}
-#       {:ok, %{status: 403, body: res_body}} -> {}
+#       {:ok, %{status: 404}} -> {}
 #       {:error, reason} -> {}
 #     end
 #   end

--- a/test/lib/linkit_test.exs
+++ b/test/lib/linkit_test.exs
@@ -36,20 +36,10 @@ defmodule IotIntern.Controller.LinkitTest do
     assert Linkit.post_message("message") == {201, expected}
   end
 
-  test "Linkit.post_message returns 403" do
-    res_body = """
-    {
-      "result": "failed",
-      "error_code": 40301,
-      "error_message": "chat room members limit exceeded"
-    }
-    """
+  test "Linkit.post_message returns 404" do
+    :meck.expect(Httpc, :post, 3, {:ok, %{status: 404}})
 
-    :meck.expect(Httpc, :post, 3, {:ok, %{status: 403, body: res_body}})
-
-    expected = Jason.decode!(res_body)
-
-    assert Linkit.post_message("message") == {403, expected}
+    assert Linkit.post_message("message") == {404}
   end
 
   test "Linkit.post_message returns error with timeout" do


### PR DESCRIPTION
## Link
Slack
- 経緯
  https://accessjp.slack.com/archives/C050S9UGESX/p1693290738889739
- 仕様書
  https://accessjp.slack.com/archives/C050S9UGESX/p1693298805028859

## やったこと
レスポンスの403になっていた下記のファイルを修正
- 仕様書
- 課題のコード
  404の場合、レスポンスボディはないので削除
- 講義資料
  こちらについてはSlackで触れていなかったが、not_foundで403を返すのはおかしいと考えたため修正

## 制限事項
解答(exampleブランチ)について、別PRで対応する必要あり