### PR TITLE
Update livebook version on EC2 startup

### DIFF
--- a/doc/elixir-training-with-livebook/makefile_for_ec2
+++ b/doc/elixir-training-with-livebook/makefile_for_ec2
@@ -1,3 +1,3 @@
 .PHONY: run
 run:
-	docker run --name Elixircise -p 8888:8888 -p 8889:8889 --pull always -e LIVEBOOK_PASSWORD="AccessIoTIntern" -v /home/intern-user/IoTIntern/doc/elixir-training-with-livebook/notebooks:/data -e LIVEBOOK_PORT="8888" -e LIVEBOOK_IFRAME_PORT="8889" ghcr.io/livebook-dev/livebook:0.9.2
+	docker run --name Elixircise -p 8888:8888 -p 8889:8889 --pull always -e LIVEBOOK_PASSWORD="AccessIoTIntern" -v /home/intern-user/IoTIntern/doc/elixir-training-with-livebook/notebooks:/data -e LIVEBOOK_PORT="8888" -e LIVEBOOK_IFRAME_PORT="8889" ghcr.io/livebook-dev/livebook:0.12.1


### PR DESCRIPTION
## やったこと
https://github.com/access-company/IoTIntern/pull/50 でLivebookのバージョンが更新されていたが、EC2インスタンス起動時のlivebookのバージョンが更新されていなかったので、それに追従する形で修正した。