### PR TITLE
antikythera 概要を分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,39 +63,6 @@ Linkit アカウント登録完了メールにパスワードが記載されて�
 └── web // API 記述先
 ```
 
-## Antikythera概要
-
-### WebサーバーとしてのAntikythera
-
-[Antikythera](https://github.com/access-company/antikythera)は複数のwebサービスをホスティングするPlatform as a Serviceです。
-Antikytheraにホスティングされた個々のwebサービスをgearと呼んでいます。
-AntikytheraはErlang VM上で動くErlangプロセスの1つであり、gearもまたAntikytheraと同じErlang VM上で動いています。
-
-- Antikytheraの機能
-    - HTTPサーバー
-      - クライアントからのHTTPリクエストに対し、Antikytheraが管理しているErlangプロセスを使ってgearの関数を呼び出し、処理を行います。
-      - 処理結果をHTTPレスポンスとしてクライアントに返します。
-    - Web Socketの管理
-    - (図には書いていないが) gearが任意の非同期処理を行うための機能提供
-
-![Overview of antikythera framework](/overview_of_antikythera.png)
-
-### HTTPリクエストに対しHTTPレスポンスが返るまでの流れ
-
-1. AntikytheraがクライアントからのHTTPリクエストを受け取ります。
-2. Antikytheraがgearの関数を呼び出します。
-   1. リクエストURLによって処理を行うgearが決まります。
-       - サブドメインに基づく
-   2. リクエストのメソッドとURLのパスによって処理を行う関数が決まります。
-       - gearの`web/router.ex`に基づく
-       - このファイルにはメソッド・パスの組に対して呼び出されるべき関数(コントローラーと呼ぶ)が定義されています。
-   3. gearのコントローラーが実行されます。
-       - コントローラーはHTTPリクエストを表すデータ構造を受け取り、HTTPレスポンスを表すデータ構造を返す関数です。
-       - レスポンスボディは必要に応じてHTMLやJSONに加工します(ビューの関数を呼び出します)
-3. AntikytheraがクライアントにHTTPレスポンスを返します。
-
-Gear開発者はコントローラーを起点として、HTTPリクエストに対しどのような処理を行うべきか、どのようなHTTPレスポンスを返すべきかに集中することができます。
-
 ## API 追加のやり方
 
 API を追加するには「コントローラーの処理を書くこと」と「ルーターのパスを設定する」の二つを行います。

--- a/overview_of_antikythera.md
+++ b/overview_of_antikythera.md
@@ -1,0 +1,32 @@
+## Antikythera概要
+
+### WebサーバーとしてのAntikythera
+
+[Antikythera](https://github.com/access-company/antikythera)は複数のwebサービスをホスティングするPlatform as a Serviceです。
+Antikytheraにホスティングされた個々のwebサービスをgearと呼んでいます。
+AntikytheraはErlang VM上で動くErlangプロセスの1つであり、gearもまたAntikytheraと同じErlang VM上で動いています。
+
+- Antikytheraの機能
+    - HTTPサーバー
+      - クライアントからのHTTPリクエストに対し、Antikytheraが管理しているErlangプロセスを使ってgearの関数を呼び出し、処理を行います。
+      - 処理結果をHTTPレスポンスとしてクライアントに返します。
+    - Web Socketの管理
+    - (図には書いていないが) gearが任意の非同期処理を行うための機能提供
+
+![Overview of antikythera framework](/overview_of_antikythera.png)
+
+### HTTPリクエストに対しHTTPレスポンスが返るまでの流れ
+
+1. AntikytheraがクライアントからのHTTPリクエストを受け取ります。
+2. Antikytheraがgearの関数を呼び出します。
+   1. リクエストURLによって処理を行うgearが決まります。
+       - サブドメインに基づく
+   2. リクエストのメソッドとURLのパスによって処理を行う関数が決まります。
+       - gearの`web/router.ex`に基づく
+       - このファイルにはメソッド・パスの組に対して呼び出されるべき関数(コントローラーと呼ぶ)が定義されています。
+   3. gearのコントローラーが実行されます。
+       - コントローラーはHTTPリクエストを表すデータ構造を受け取り、HTTPレスポンスを表すデータ構造を返す関数です。
+       - レスポンスボディは必要に応じてHTMLやJSONに加工します(ビューの関数を呼び出します)
+3. AntikytheraがクライアントにHTTPレスポンスを返します。
+
+Gear開発者はコントローラーを起点として、HTTPリクエストに対しどのような処理を行うべきか、どのようなHTTPレスポンスを返すべきかに集中することができます。


### PR DESCRIPTION
## 対応内容
README.md 内に記載されていた「antikythera 概要」を別ファイルに移しました。