### PR TITLE
linkit_test の res_body を API 仕様書に合わせる形で修正

### DIFF
--- a/test/lib/linkit_test.exs
+++ b/test/lib/linkit_test.exs
@@ -14,8 +14,6 @@ defmodule IotIntern.Controller.LinkitTest do
       "chat_message": {
         "_id": "2456598c88d3fdd8aa000017",
         "chat_room_id": "33398950c711636832000059",
-        "data": {},
-        "importance": "normal",
         "is_deleted": false,
         "message": "脱輪",
         "msg_seq": 10230,
@@ -25,7 +23,6 @@ defmodule IotIntern.Controller.LinkitTest do
         "unread_count": 1,
         "user_id": "1267712707"
       },
-      "server_time": "2015-07-22T00:57:45Z"
     }
     """
 

--- a/test/lib/linkit_test.exs
+++ b/test/lib/linkit_test.exs
@@ -22,7 +22,7 @@ defmodule IotIntern.Controller.LinkitTest do
         "type": "string",
         "unread_count": 1,
         "user_id": "1267712707"
-      },
+      }
     }
     """
 

--- a/test/lib/linkit_test.exs
+++ b/test/lib/linkit_test.exs
@@ -15,7 +15,7 @@ defmodule IotIntern.Controller.LinkitTest do
         "_id": "2456598c88d3fdd8aa000017",
         "chat_room_id": "33398950c711636832000059",
         "is_deleted": false,
-        "message": "脱輪",
+        "message": "脱輪が発生しました",
         "msg_seq": 10230,
         "post_date": "2015-07-22T00:57:45Z",
         "request_id": "d80979c1-624c-4b9e-91e3-d1a0a713c7d01437526664419",


### PR DESCRIPTION
## 対応内容

[振り返り項目](https://docs.google.com/spreadsheets/d/1bykJ1GD0tX-nX5Hd6qlNxmZBxO5Xp8kJX5VSCJq0pNQ/edit?gid=0#gid=0&range=19:20) 関する修正です。

`linkit_test.exs` に含まれる `res_body` が API 仕様書で書かれているレスポンスボディの中身と異なっていたため修正しました。

実際のレスポンスボディとしてはテストコード側が正しいため、API 仕様書を修正すべきですが、対応に時間がかかりそうなので、今回は暫定的にテストコードの方を修正しました。
インターンが終了したら API 仕様書を修正しようと思います。
