### PR TITLE
.formatter.exs を追加して mix format を適用

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{lib,test,web}/**/*.{ex,exs}"],
+  locals_without_parens: [defun: 2, defunp: 2, defunpt: 2, defpt: 2]
+]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ IOT_INTERN_CONFIG_JSON=$(cat gear_config.json) mix test
 IOT_INTERN_CONFIG_JSON=$(cat gear_config.json) mix test test/web/controller/hello_test.exs
 ```
 
+## コードフォーマット
+
+コードのフォーマットを整えるには、下記コマンドを実行します。
+
+```sh
+mix format
+```
+
 ## お掃除ロボットの API 実装課題
 
 [apidoc branch](https://github.com/access-company/IoTIntern/tree/apidoc) 上の [仕様書](https://github.com/access-company/IoTIntern/blob/apidoc/doc/api.apib) と [シーケンス図](https://github.com/access-company/IoTIntern/blob/apidoc/doc/sequence.puml) の通りに実装することを目指します。

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -1,14 +1,14 @@
 defmodule IotIntern.Error do
   def bad_request_error() do
     %{
-      type:    "BadRequest",
+      type: "BadRequest",
       message: "Unable to understand the request"
     }
   end
 
   def linkit_error() do
     %{
-      type:    "LinkitError",
+      type: "LinkitError",
       message: "Error caused on Linkit"
     }
   end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -3,7 +3,7 @@ use Croma
 defmodule IotIntern.Gettext do
   use Antikythera.Gettext, otp_app: :iot_intern
 
-  defun put_locale(locale :: v[String.t]) :: nil do
+  defun put_locale(locale :: v[String.t()]) :: nil do
     Gettext.put_locale(__MODULE__, locale)
   end
 end

--- a/lib/iot_intern.ex
+++ b/lib/iot_intern.ex
@@ -2,7 +2,7 @@ defmodule IotIntern do
   use Antikythera.GearApplication
   alias Antikythera.{ExecutorPool, Conn}
 
-  @type child_spec :: :supervisor.child_spec | {module, term} | module
+  @type child_spec :: :supervisor.child_spec() | {module, term} | module
 
   @spec children :: [child_spec]
   def children() do
@@ -11,7 +11,7 @@ defmodule IotIntern do
     ]
   end
 
-  @spec executor_pool_for_web_request(Conn.t) :: ExecutorPool.Id.t
+  @spec executor_pool_for_web_request(Conn.t()) :: ExecutorPool.Id.t()
   def executor_pool_for_web_request(_conn) do
     # specify executor pool to use; change the following line if your gear serves to multiple tenants
     {:gear, :iot_intern}

--- a/mix.exs
+++ b/mix.exs
@@ -1,25 +1,32 @@
-instance_dep = {:antikythera_instance_example, [git: "https://github.com/access-company/antikythera_instance_example.git"]}
+instance_dep =
+  {:antikythera_instance_example,
+   [git: "https://github.com/access-company/antikythera_instance_example.git"]}
 
 try do
+  # Gears use mix settings of both antikythera and antikythera instance and thus paths to these projects must be available.
+  # We have to remember `deps_path()` so that gear dependencies with `:path` option can reach these projects.
   deps_dir =
-    # Gears use mix settings of both antikythera and antikythera instance and thus paths to these projects must be available.
-    # We have to remember `deps_path()` so that gear dependencies with `:path` option can reach these projects.
     case Application.get_env(:antikythera, :compile_time_deps_dir) do
-      nil -> # this gear project is the toplevel mix project
+      # this gear project is the toplevel mix project
+      nil ->
         deps_path = Mix.Project.deps_path()
         Application.put_env(:antikythera, :compile_time_deps_dir, deps_path)
         deps_path
-      deps_path -> deps_path # this gear project is used by another gear as a gear dependency
+
+      # this gear project is used by another gear as a gear dependency
+      deps_path ->
+        deps_path
     end
+
   Code.require_file(Path.join([deps_dir, "antikythera", "mix_common.exs"]))
 
   defmodule IotIntern.Mixfile do
-    use Antikythera.GearProject, [
-      antikythera_instance_dep: instance_dep,
-    ]
+    use Antikythera.GearProject,
+      antikythera_instance_dep: instance_dep
 
     defp gear_name(), do: :iot_intern
-    defp version()  , do: "0.0.1"
+    defp version(), do: "0.0.1"
+
     defp gear_deps() do
       [
         # List of gear dependencies, e.g.
@@ -34,8 +41,8 @@ rescue
 
       def project() do
         [
-          app:  :just_to_fetch_antikythera_instance_as_a_dependency,
-          deps: [unquote(instance_dep)],
+          app: :just_to_fetch_antikythera_instance_as_a_dependency,
+          deps: [unquote(instance_dep)]
         ]
       end
     end

--- a/test/web/controller/hello_test.exs
+++ b/test/web/controller/hello_test.exs
@@ -14,6 +14,7 @@ defmodule IotIntern.Controller.HelloTest do
     # :meck.expect(Httpc, :get, fn _url -> :ok end)
 
     headers = %{"auth" => "xxxx"}
+
     Enum.each(["hello", "world"], fn message ->
       req_body = %{"message" => message}
       res = Req.post_json(@api_path, req_body, headers)

--- a/web/controller/hello.ex
+++ b/web/controller/hello.ex
@@ -10,11 +10,12 @@ defmodule IotIntern.Controller.Hello do
   def hello(%{request: req} = conn) do
     %{
       headers: %{
-        "auth" => auth,
+        "auth" => auth
       },
-      body: %{
-        "message" => msg,
-      } = req_body,
+      body:
+        %{
+          "message" => msg
+        } = req_body
     } = req
 
     # NOTE: リクエストの呼び出しは下記のように行うがテストでは実際にリクエストを行わないよう :meck を使う。
@@ -22,7 +23,7 @@ defmodule IotIntern.Controller.Hello do
 
     case {auth, msg} do
       {"xxxx", msg} when msg in ["hello", "world"] -> Conn.json(conn, 200, req_body)
-      _                                            -> Conn.json(conn, 400, %{"message" => "ng"})
+      _ -> Conn.json(conn, 400, %{"message" => "ng"})
     end
   end
 end

--- a/web/controller/hello_croma.ex
+++ b/web/controller/hello_croma.ex
@@ -10,15 +10,17 @@ defmodule IotIntern.Controller.HelloCroma do
       use Croma.SubtypeOfAtom, values: [:hello, :world]
     end
 
-    use Croma.Struct, recursive_new?: true, fields: [
-      message: Message,
-    ]
+    use Croma.Struct,
+      recursive_new?: true,
+      fields: [
+        message: Message
+      ]
   end
 
   def hello(%{request: %{body: req_body}} = conn) do
     case RequestBody.new(req_body) do
       {:ok, _} -> Conn.json(conn, 200, req_body)
-      _        -> Conn.json(conn, 400, %{"message" => "ng"})
+      _ -> Conn.json(conn, 400, %{"message" => "ng"})
     end
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -1,10 +1,10 @@
 defmodule IotIntern.Router do
   use Antikythera.Router
 
-  static_prefix "/ui"
+  static_prefix("/ui")
 
-  post "/api/v1/hello",       Hello,      :hello
-  post "/api/v1/hello-croma", HelloCroma, :hello_with_croma
+  post("/api/v1/hello", Hello, :hello)
+  post("/api/v1/hello-croma", HelloCroma, :hello_with_croma)
 
-  post "/api/v1/alert",       Alert,      :post_alert
+  post("/api/v1/alert", Alert, :post_alert)
 end


### PR DESCRIPTION
## Summary
- `.formatter.exs` を追加して `mix format` を利用可能にする (054894e)
- 既存コードに `mix format` を適用 (aa76602)
- README に `mix format` の使い方を追記 (7707b2b)

フォーマット適用による差分は aa76602 を参照してください。