### PR TITLE
VSCode 拡張機能を更新 (Lexical 導入, OpenAPI 更新, Spell Checker 追加)

### DIFF
--- a/doc/for_participants/setup_on_remote_machine.md
+++ b/doc/for_participants/setup_on_remote_machine.md
@@ -16,6 +16,7 @@ IoTInternでの開発を行う際に以下の拡張機能を利用する。
 - [Git Graph](https://marketplace.visualstudio.com/items?itemName=mhutchie.git-graph): Gitのコミットグラフを可視化できる
 - [Lexical](https://marketplace.visualstudio.com/items?itemName=lexical-lsp.lexical): Elixirの言語サーバー。syntax highlighting、入力補完、定義の参照・移動が可能
 - [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker): スペルチェッカー
+- [Live Share](https://marketplace.visualstudio.com/items?itemName=ms-vsliveshare.vsliveshare): リアルタイム共同編集（必要に応じて利用）
 
 ### インストール
 

--- a/doc/for_participants/setup_on_remote_machine.md
+++ b/doc/for_participants/setup_on_remote_machine.md
@@ -14,10 +14,8 @@ IoTInternでの開発を行う際に以下の拡張機能を利用する。
 - [Plant UML](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml): シーケンス図のレンダリングが可能
 - [OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi): OpenAPI形式の仕様書を編集・プレビュー可能
 - [Git Graph](https://marketplace.visualstudio.com/items?itemName=mhutchie.git-graph): Gitのコミットグラフを可視化できる
-- [vscode-elixir](https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir): syntax highlightingや入力補完ができるようになる
-    - [Elixir-LS](https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls)のほうが定義の参照や定義箇所への移動ができるなど高機能だが、下記の問題により無視できない不便さが生じたため使用していない
-        - IoTInternで利用する際、最新のものではなくバージョン0.5.0を利用しなければ拡張機能がクラッシュする(AntikytheraがErlangバージョン20系を要求することによる)
-        - IoTIntern gearコンパイル時にhexパッケージのコンパイルが失敗する場合がある(バックグラウンドでElixir-LSによるgearコンパイルが進行している時に処理がバッティングすることによる)
+- [Lexical](https://marketplace.visualstudio.com/items?itemName=lexical-lsp.lexical): Elixirの言語サーバー。syntax highlighting、入力補完、定義の参照・移動が可能
+- [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker): スペルチェッカー
 
 ### インストール
 

--- a/script/util/install_vscode_extensions.sh
+++ b/script/util/install_vscode_extensions.sh
@@ -20,13 +20,16 @@ install_extension(){
 install_extension jebbs plantuml 2.18.1
 
 # https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi
-install_extension 42Crunch vscode-openapi 5.2.0
+install_extension 42Crunch vscode-openapi 5.3.0
 
 # https://marketplace.visualstudio.com/items?itemName=mhutchie.git-graph
 install_extension mhutchie git-graph 1.30.0
 
-# https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir
-install_extension mjmcloug vscode-elixir 1.1.0
+# https://marketplace.visualstudio.com/items?itemName=lexical-lsp.lexical
+install_extension lexical-lsp lexical 0.0.24
 
 # https://marketplace.visualstudio.com/items?itemName=ms-vsliveshare.vsliveshare
 install_extension ms-vsliveshare vsliveshare 1.0.5959
+
+# https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker
+install_extension streetsidesoftware code-spell-checker 4.6.0


### PR DESCRIPTION
## Summary
- Elixir 言語サーバーを vscode-elixir から Lexical に変更
- OpenAPI (Swagger) Editor を 5.2.0 → 5.3.0 に更新
- Code Spell Checker を新規追加