### PR TITLE
.gitignore の linkit_api を apib から yaml に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ erl_crash.dump
 *.ez
 /node_modules
 gear_config.json
-/doc/linkit_api.apib
+/doc/linkit_api.yaml
 .DS_Store
 /tmp-downloaded


### PR DESCRIPTION
## Summary
- API 仕様書を OpenAPI 形式 (yaml) に変換したことに伴い、.gitignore の除外対象を更新