### PR TITLE
EC2インスタンスタイプをt3.microからt3.smallに変更

### DIFF
--- a/script/aws/launch_instances.sh
+++ b/script/aws/launch_instances.sh
@@ -32,7 +32,7 @@ run_instances(){
     --profile iot_intern \
     --image-id "${image_id}" \
     --count "${instance_count}" \
-    --instance-type 't3.micro' \
+    --instance-type 't3.small' \
     --security-group-ids "${security_group_id}" \
     --tag-specifications "ResourceType='instance',Tags=[{Key='Name',Value='iot-intern'}]"
 }

--- a/script/aws/launch_makeami_instance.sh
+++ b/script/aws/launch_makeami_instance.sh
@@ -67,7 +67,7 @@ run_instance() {
   aws ec2 run-instances \
     --profile iot_intern \
     --image-id "$image_id" \
-    --instance-type "t3.micro" \
+    --instance-type "t3.small" \
     --subnet-id "$subnet_id" \
     --user-data "file://${file}" \
     --block-device-mappings "$block_device_mappings" \


### PR DESCRIPTION
## 対応内容
インターン用EC2インスタンスで接続が突然切断される事象が発生し、調査の結果メモリ不足が原因と判明しました。VS Code拡張機能等の常駐メモリにより、現行の`t3.micro`ではメモリが逼迫するため、インスタンスタイプを`t3.small`に変更します。

対象ファイル:
- script/aws/launch_instances.sh
- script/aws/launch_makeami_instance.sh

リハーサルにて変更後の動作確認済みです。